### PR TITLE
feat: scone cli functionalities

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -217,6 +217,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.103"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -522,6 +528,12 @@ dependencies = [
  "libc",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "fastrand"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "find-msvc-tools"
@@ -1044,6 +1056,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
 name = "litemap"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1496,6 +1514,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "rustls"
 version = "0.23.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1602,10 +1633,13 @@ dependencies = [
 
 [[package]]
 name = "scone_cli"
-version = "3.0.0"
+version = "3.1.0"
 dependencies = [
+ "anyhow",
  "log",
+ "semver",
  "spawn_server",
+ "tempfile",
 ]
 
 [[package]]
@@ -1789,8 +1823,8 @@ dependencies = [
 
 [[package]]
 name = "spawn_server"
-version = "2.0.0"
-source = "git+https://github.com/scontain/spawn_server.git?rev=f91b8e0f0db272f6595ed9a4d23e14a2d82d6d27#f91b8e0f0db272f6595ed9a4d23e14a2d82d6d27"
+version = "2.1.0"
+source = "git+https://github.com/scontain/spawn_server.git?rev=c7211c04d9fac018326e8c742bf22b9b4c92ceba#c7211c04d9fac018326e8c742bf22b9b4c92ceba"
 dependencies = [
  "actix-rt",
  "actix-web",
@@ -1866,6 +1900,19 @@ checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
 dependencies = [
  "core-foundation-sys",
  "libc",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.4.3",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scone_cli"
-version = "3.0.0"
+version = "3.1.0"
 edition = "2024"
 publish = false
 license = "Unlicense"
@@ -9,4 +9,7 @@ license = "Unlicense"
 
 [dependencies]
 log = "0.4.29"
-spawn_server = { version = "2.0.0", git = "https://github.com/scontain/spawn_server.git", rev = "f91b8e0f0db272f6595ed9a4d23e14a2d82d6d27" }
+spawn_server = { version = "2.1.0", git = "https://github.com/scontain/spawn_server.git", rev = "c7211c04d9fac018326e8c742bf22b9b4c92ceba" }
+anyhow = "1.0"
+semver = "1"
+tempfile = "3"

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -1,0 +1,328 @@
+use log::{info, warn};
+use spawn_server::{
+    SpawnServerCommandResponse, run_local_exec, run_local_shell, srpc_exec, srpc_sh,
+};
+use std::env;
+use std::net::{Ipv4Addr, SocketAddrV4};
+use std::process::Command;
+use std::sync::{Mutex, OnceLock};
+
+const DOCKER_NETWORK: &str = ""; // --network=host
+
+pub const SCONECLI_BINARY: &str = "scone";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SconeCliCommandType {
+    SpawnServerSconeCli,
+    SpawnServerDocker,
+    SconeCli,
+    Docker,
+    SpawnServer,
+    None,
+}
+
+static SCONE_CLI_COMMAND_TYPE: OnceLock<SconeCliCommandType> = OnceLock::new();
+
+pub fn get_scone_cli_command_type() -> &'static SconeCliCommandType {
+    SCONE_CLI_COMMAND_TYPE.get_or_init(compute_scone_cli_command_type)
+}
+
+fn compute_scone_cli_command_type() -> SconeCliCommandType {
+    info!("Determining how to execute the shell commands");
+
+    let SpawnServerCommandResponse { exit_code, .. } = srpc_exec!(
+        SCONECLI_BINARY,
+        ["--version"],
+        [("SCONE_PRODUCTION", "0")],
+        ["SCONE_PRODUCTION"]
+    );
+
+    if exit_code == 0 {
+        info!("Both spawn_server and scone cli are installed");
+        return SconeCliCommandType::SpawnServerSconeCli;
+    }
+
+    if exit_code == -1 {
+        return if local_scone_installed() {
+            info!("scone cli, but not spawn_server, is installed");
+            SconeCliCommandType::SconeCli
+        } else if local_docker_installed() {
+            info!("docker, but neither scone cli nor spawn_server, is installed");
+            SconeCliCommandType::Docker
+        } else {
+            info!("Neither spawn_server, docker, nor scone cli is installed");
+            SconeCliCommandType::None
+        };
+    }
+
+    if local_docker_installed() {
+        info!("docker and spawn_server, but not scone cli, is installed");
+        SconeCliCommandType::SpawnServerDocker
+    } else {
+        info!("spawn_server, but neither docker nor scone cli, is installed");
+        SconeCliCommandType::SpawnServer
+    }
+}
+
+pub fn local_scone_installed() -> bool {
+    match Command::new(SCONECLI_BINARY)
+        .arg("--version")
+        .env_remove("SCONE_PRODUCTION")
+        .env("SCONE_PRODUCTION", "0")
+        .output()
+    {
+        Ok(out) => out.status.success(),
+        Err(_) => false,
+    }
+}
+
+pub fn local_docker_installed() -> bool {
+    match Command::new("docker").arg("--version").output() {
+        Ok(out) => out.status.success(),
+        Err(_) => false,
+    }
+}
+
+static VERSION: OnceLock<Mutex<String>> = OnceLock::new();
+
+fn ensure_version() -> &'static Mutex<String> {
+    VERSION.get_or_init(|| Mutex::new(String::from("latest")))
+}
+
+pub fn set_version<S: Into<String>>(version: S) {
+    *ensure_version().lock().unwrap() = version.into();
+}
+
+pub fn get_version() -> String {
+    ensure_version().lock().unwrap().clone()
+}
+
+#[derive(Clone, Debug)]
+pub struct SconeCliCommandResult {
+    pub exit_code: i32,
+    pub stdout: String,
+    pub stderr: String,
+}
+
+impl From<SpawnServerCommandResponse> for SconeCliCommandResult {
+    fn from(r: SpawnServerCommandResponse) -> Self {
+        Self {
+            exit_code: r.exit_code,
+            stdout: r.stdout,
+            stderr: r.stderr,
+        }
+    }
+}
+
+impl std::error::Error for SconeCliCommandResult {}
+
+impl std::fmt::Display for SconeCliCommandResult {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "command exited with code {}", self.exit_code)?;
+        if !self.stdout.is_empty() {
+            write!(f, "\n  Standard Output:\n")?;
+            for line in self.stdout.lines() {
+                writeln!(f, "    {}", line)?;
+            }
+        }
+
+        if !self.stderr.is_empty() {
+            write!(f, "\n  Standard Error:\n")?;
+            for line in self.stderr.lines() {
+                writeln!(f, "    {}", line)?;
+            }
+        }
+        Ok(())
+    }
+}
+
+/// Execute a scone command.
+///
+/// - If `spawn_server` is installed, the binary is exec'd directly through
+///   it (no shell).
+/// - If `spawn_server` is unavailable but `scone` is installed locally, it is
+///   exec'd directly via `std::process::Command`.
+/// - If neither is available but `docker` is, the command runs inside a
+///   docker container via a shell (needed for `$HOME`/`$(id -u)` expansion).
+///   **`env_remove` has no effect on this path** -- a fresh container has no
+///   inherited host env to remove in the first place, so anything in
+///   `env_remove` is only logged, not acted on.
+/// - Otherwise, this bails.
+///
+/// `args` should NOT include the binary name itself.
+/// `env_remove` is applied before `env`, so a key present in both ends up
+/// removed then re-set (i.e. `env` wins on conflicts).
+pub fn execute_scone_cli<S, R>(
+    args: &[String],
+    env: impl IntoIterator<Item = (S, S)>,
+    env_remove: impl IntoIterator<Item = R>,
+) -> SconeCliCommandResult
+where
+    S: AsRef<str>,
+    R: AsRef<str>,
+{
+    let env_vec: Vec<(String, String)> = env
+        .into_iter()
+        .map(|(k, v)| (k.as_ref().to_string(), v.as_ref().to_string()))
+        .collect();
+    let env_remove_vec: Vec<String> = env_remove
+        .into_iter()
+        .map(|k| k.as_ref().to_string())
+        .collect();
+
+    match *get_scone_cli_command_type() {
+        SconeCliCommandType::SpawnServerSconeCli => {
+            srpc_exec!(SCONECLI_BINARY, args.to_vec(), env_vec, env_remove_vec).into()
+        }
+        SconeCliCommandType::SpawnServerDocker => {
+            if !env_remove_vec.is_empty() {
+                warn!(
+                    "env_remove ({:?}) is not necessary as No env var from the parent process is forwarded to the child process since we use docker (ERROR 15092-2233-1)",
+                    env_remove_vec
+                );
+            }
+            let docker_env = construct_docker_env(&env_vec);
+            srpc_sh!(
+                "{}",
+                build_docker_command(SCONECLI_BINARY, args, &docker_env)
+            )
+            .into()
+        }
+        SconeCliCommandType::SconeCli => {
+            run_local_exec(SCONECLI_BINARY, args, &env_vec, &env_remove_vec).into()
+        }
+        SconeCliCommandType::Docker => {
+            if !env_remove_vec.is_empty() {
+                warn!(
+                    "env_remove ({:?}) is not necessary as No env var from the parent process is forwarded to the child process since we use docker (ERROR 15092-2233-1)",
+                    env_remove_vec
+                );
+            }
+            let docker_env = construct_docker_env(&env_vec);
+            let full_command = build_docker_command(SCONECLI_BINARY, args, &docker_env);
+            run_local_shell(&full_command).into()
+        }
+        SconeCliCommandType::SpawnServer | SconeCliCommandType::None => SconeCliCommandResult {
+            exit_code: -3,
+            stdout: String::new(),
+            stderr: format!(
+                "Failed to execute SCONE command '{SCONECLI_BINARY} {}': Neither '{SCONECLI_BINARY}' nor 'docker' is installed (ERROR 20154-13302-17922)",
+                args.join(" ")
+            ),
+        },
+    }
+}
+
+pub const DEBUG_SCONE_CLI_ENV: &[(&str, &str)] = &[
+    ("SCONE_PRODUCTION", "0"),
+    ("SCONE_NO_TIME_THREAD", "1"),
+    ("SCONE_MODE", "sim"),
+];
+
+/// Executes a SCONE cli command in one of the supported modes.
+///
+/// # Examples
+/// ```ignore
+/// exec_scone!(debug, "cas", "list");
+/// exec_scone!(production, "cas", "list");
+/// exec_scone!(custom, env, "cas", "list");                       // env_remove defaults to []
+/// exec_scone!(custom, env, remove ["SCONE_CONFIG_ID"], "cas", "list");
+/// ```
+#[macro_export]
+macro_rules! exec_scone {
+    (debug, $( $arg:expr ),+ $(,)?) => {{
+        $crate::execute_scone_cli(
+            &[$( $arg.to_string() ),+],
+            $crate::DEBUG_SCONE_CLI_ENV.iter().copied(),
+            Vec::<&str>::new(),
+        )
+    }};
+
+    (production, $( $arg:expr ),+ $(,)?) => {{
+        $crate::execute_scone_cli(
+            &[$( $arg.to_string() ),+],
+            Vec::<(&str, &str)>::new(),
+            Vec::<&str>::new(),
+        )
+    }};
+
+    (custom, $env:expr, remove $env_remove:expr, $( $arg:expr ),+ $(,)?) => {{
+        $crate::execute_scone_cli(
+            &[$( $arg.to_string() ),+],
+            $env,
+            $env_remove,
+        )
+    }};
+
+    (custom, $env:expr, $( $arg:expr ),+ $(,)?) => {{
+        $crate::execute_scone_cli(
+            &[$( $arg.to_string() ),+],
+            $env,
+            Vec::<&str>::new(),
+        )
+    }};
+}
+
+/// Executes a SCONE cli command in production mode. See `exec_scone!()` for other modes.
+#[macro_export]
+macro_rules! scone {
+    ( $( $arg:expr ),+ $(,)? ) => {{
+        $crate::execute_scone_cli(
+            &[$( $arg.to_string() ),+],
+            Vec::<(&str, &str)>::new(),
+            Vec::<&str>::new(),
+        )
+    }};
+}
+
+fn construct_docker_env(envs: &[(String, String)]) -> Vec<String> {
+    let mut args = vec![];
+    for (k, v) in envs {
+        args.push("-e".to_string());
+        args.push(format!("{k}={v}"));
+    }
+    args
+}
+
+fn shell_quote(s: &str) -> String {
+    format!("'{}'", s.replace('\'', r"'\''"))
+}
+
+fn build_docker_command(binary: &str, args: &[String], env_args: &[String]) -> String {
+    let repo =
+        env::var("SCONECTL_REPO").unwrap_or_else(|_| "registry.scontain.com/sconectl".to_string());
+
+    let vol = match env::var("DOCKER_HOST") {
+        Ok(val) => {
+            if val.starts_with("unix://") {
+                let vol = val.strip_prefix("unix://").unwrap_or(&val).to_string();
+                format!(r#"-e DOCKER_HOST="{val}" -v "{vol}":"{vol}""#)
+            } else if val.starts_with("tcp://") {
+                warn!(
+                    "Docker socket with TCP schema was detected. Will use DOCKER_HOST={val} to access docker socket inside container."
+                );
+                format!(r#"-e DOCKER_HOST="{val}""#)
+            } else if val.parse::<Ipv4Addr>().is_ok() || val.parse::<SocketAddrV4>().is_ok() {
+                warn!(
+                    "IP address was detected. Will use DOCKER_HOST=tcp://{val} to access docker socket inside container."
+                );
+                format!(r#"-e DOCKER_HOST="tcp://{val}""#)
+            } else {
+                warn!("Docker socket: {} with unknown schema was detected.", val);
+                r#"-e DOCKER_HOST=/var/run/docker.sock -v /var/run/docker.sock:/var/run/docker.sock"#.to_string()
+            }
+        }
+        Err(_e) => "-v /var/run/docker.sock:/var/run/docker.sock".to_string(),
+    };
+
+    let env_vars_str = env_args.join(" ");
+    let quoted_args: Vec<String> = args.iter().map(|a| shell_quote(a)).collect();
+    let scone_command = format!("{binary} {}", quoted_args.join(" "));
+
+    let docker_command = format!(
+        r#"docker run --rm --platform linux/amd64 --add-host=host.docker.internal:host-gateway {DOCKER_NETWORK} {env_vars_str} --entrypoint="" -e "SCONECTL_REPO={repo}" {vol} -v "$HOME/.docker:/home/root/.docker" -v "$HOME/.cas:/home/nonroot/.cas" -v "$HOME/.scone:/home/nonroot/.scone" -v "$PWD:/wd" -w /wd --user $(id -u):$(id -g) --group-add $(getent group docker | cut -d: -f3)   {repo}/sconecli:{} sh -c '{scone_command}'"#,
+        get_version()
+    );
+    info!("Executing: {docker_command}");
+    docker_command
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,319 +1,348 @@
-use log::{info, warn};
-use spawn_server::{
-    SpawnServerCommandResponse, run_local_exec, run_local_shell, srpc_exec, srpc_sh,
+mod engine;
+
+use anyhow::{Context, bail};
+use log::{debug, info, warn};
+use semver::{Version, VersionReq};
+use std::{
+    io::Write,
+    path::{Path, PathBuf},
 };
-use std::env;
-use std::net::{Ipv4Addr, SocketAddrV4};
-use std::process::Command;
-use std::sync::{Mutex, OnceLock};
+use tempfile::NamedTempFile;
 
-const DOCKER_NETWORK: &str = ""; // --network=host
+pub use engine::*;
 
-pub const SCONECLI_BINARY: &str = "scone";
+pub(crate) const K_MRSIGNER_DB: &str =
+    "195e5a6df987d6a515dd083750c1ea352283f8364d3ec9142b0d593988c6ed2d";
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum SconeCliCommandType {
-    SpawnServerSconeCli,
-    SpawnServerDocker,
-    SconeCli,
-    Docker,
-    SpawnServer,
-    None,
+pub enum OutputDest {
+    Temp,
+    Fixed(PathBuf),
 }
 
-static SCONE_CLI_COMMAND_TYPE: OnceLock<SconeCliCommandType> = OnceLock::new();
-
-pub fn get_scone_cli_command_type() -> &'static SconeCliCommandType {
-    SCONE_CLI_COMMAND_TYPE.get_or_init(compute_scone_cli_command_type)
-}
-
-fn compute_scone_cli_command_type() -> SconeCliCommandType {
-    info!("Determining how to execute the shell commands");
-
-    let SpawnServerCommandResponse { exit_code, .. } = srpc_exec!(SCONECLI_BINARY, ["--version"]);
-
-    if exit_code == 0 {
-        info!("Both spawn_server and scone cli are installed");
-        return SconeCliCommandType::SpawnServerSconeCli;
-    }
-
-    if exit_code == -1 {
-        return if local_scone_installed() {
-            info!("scone cli, but not spawn_server, is installed");
-            SconeCliCommandType::SconeCli
-        } else if local_docker_installed() {
-            info!("docker, but neither scone cli nor spawn_server, is installed");
-            SconeCliCommandType::Docker
-        } else {
-            info!("Neither spawn_server, docker, nor scone cli is installed");
-            SconeCliCommandType::None
-        };
-    }
-
-    if local_docker_installed() {
-        info!("docker and spawn_server, but not scone cli, is installed");
-        SconeCliCommandType::SpawnServerDocker
-    } else {
-        info!("spawn_server, but neither docker nor scone cli, is installed");
-        SconeCliCommandType::SpawnServer
-    }
-}
-
-pub fn local_scone_installed() -> bool {
-    match Command::new(SCONECLI_BINARY).arg("--version").output() {
-        Ok(out) => out.status.success(),
-        Err(_) => false,
-    }
-}
-
-pub fn local_docker_installed() -> bool {
-    match Command::new("docker").arg("--version").output() {
-        Ok(out) => out.status.success(),
-        Err(_) => false,
-    }
-}
-
-static VERSION: OnceLock<Mutex<String>> = OnceLock::new();
-
-fn ensure_version() -> &'static Mutex<String> {
-    VERSION.get_or_init(|| Mutex::new(String::from("latest")))
-}
-
-pub fn set_version<S: Into<String>>(version: S) {
-    *ensure_version().lock().unwrap() = version.into();
-}
-
-pub fn get_version() -> String {
-    ensure_version().lock().unwrap().clone()
-}
-
-#[derive(Clone, Debug)]
-pub struct SconeCliCommandResult {
-    pub exit_code: i32,
-    pub stdout: String,
-    pub stderr: String,
-}
-
-impl From<SpawnServerCommandResponse> for SconeCliCommandResult {
-    fn from(r: SpawnServerCommandResponse) -> Self {
-        Self {
-            exit_code: r.exit_code,
-            stdout: r.stdout,
-            stderr: r.stderr,
+fn write_to_dest(dest: &OutputDest, data: &[u8]) -> anyhow::Result<PersistedFile> {
+    match dest {
+        OutputDest::Temp => {
+            let tmp = NamedTempFile::new()?;
+            std::fs::write(tmp.path(), data)?;
+            Ok(PersistedFile::Temp(tmp))
+        }
+        OutputDest::Fixed(path) => {
+            std::fs::write(path, data)?;
+            Ok(PersistedFile::Fixed(path.clone()))
         }
     }
 }
 
-impl std::error::Error for SconeCliCommandResult {}
+pub enum PersistedFile {
+    Temp(NamedTempFile),
+    Fixed(PathBuf),
+}
 
-impl std::fmt::Display for SconeCliCommandResult {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "command exited with code {}", self.exit_code)?;
-        if !self.stdout.is_empty() {
-            write!(f, "\n  Standard Output:\n")?;
-            for line in self.stdout.lines() {
-                writeln!(f, "    {}", line)?;
-            }
+impl PersistedFile {
+    pub fn path(&self) -> &Path {
+        match self {
+            PersistedFile::Temp(t) => t.path(),
+            PersistedFile::Fixed(p) => p.as_path(),
         }
-
-        if !self.stderr.is_empty() {
-            write!(f, "\n  Standard Error:\n")?;
-            for line in self.stderr.lines() {
-                writeln!(f, "    {}", line)?;
-            }
-        }
-        Ok(())
     }
 }
 
-/// Execute a scone command.
-///
-/// - If `spawn_server` is installed, the binary is exec'd directly through
-///   it (no shell).
-/// - If `spawn_server` is unavailable but `scone` is installed locally, it is
-///   exec'd directly via `std::process::Command`.
-/// - If neither is available but `docker` is, the command runs inside a
-///   docker container via a shell (needed for `$HOME`/`$(id -u)` expansion).
-///   **`env_remove` has no effect on this path** -- a fresh container has no
-///   inherited host env to remove in the first place, so anything in
-///   `env_remove` is only logged, not acted on.
-/// - Otherwise, this bails.
-///
-/// `args` should NOT include the binary name itself.
-/// `env_remove` is applied before `env`, so a key present in both ends up
-/// removed then re-set (i.e. `env` wins on conflicts).
-pub fn execute_scone_cli<S, R>(
-    args: &[String],
-    env: impl IntoIterator<Item = (S, S)>,
-    env_remove: impl IntoIterator<Item = R>,
-) -> SconeCliCommandResult
-where
-    S: AsRef<str>,
-    R: AsRef<str>,
-{
-    let env_vec: Vec<(String, String)> = env
-        .into_iter()
-        .map(|(k, v)| (k.as_ref().to_string(), v.as_ref().to_string()))
-        .collect();
-    let env_remove_vec: Vec<String> = env_remove
-        .into_iter()
-        .map(|k| k.as_ref().to_string())
-        .collect();
+struct VersionedArg {
+    flag: &'static str,
+    supported: VersionReq,
+}
 
-    match *get_scone_cli_command_type() {
-        SconeCliCommandType::SpawnServerSconeCli => {
-            srpc_exec!(SCONECLI_BINARY, args.to_vec(), env_vec, env_remove_vec).into()
-        }
-        SconeCliCommandType::SpawnServerDocker => {
-            if !env_remove_vec.is_empty() {
-                warn!(
-                    "env_remove ({:?}) is not necessary as No env var from the parent process is forwarded to the child process since we use docker (ERROR 15092-2233-1)",
-                    env_remove_vec
-                );
-            }
-            let docker_env = construct_docker_env(&env_vec);
-            srpc_sh!(
-                "{}",
-                build_docker_command(SCONECLI_BINARY, args, &docker_env)
-            )
-            .into()
-        }
-        SconeCliCommandType::SconeCli => {
-            run_local_exec(SCONECLI_BINARY, args, &env_vec, &env_remove_vec).into()
-        }
-        SconeCliCommandType::Docker => {
-            if !env_remove_vec.is_empty() {
-                warn!(
-                    "env_remove ({:?}) is not necessary as No env var from the parent process is forwarded to the child process since we use docker (ERROR 15092-2233-1)",
-                    env_remove_vec
-                );
-            }
-            let docker_env = construct_docker_env(&env_vec);
-            let full_command = build_docker_command(SCONECLI_BINARY, args, &docker_env);
-            run_local_shell(&full_command).into()
-        }
-        SconeCliCommandType::SpawnServer | SconeCliCommandType::None => SconeCliCommandResult {
-            exit_code: -3,
-            stdout: String::new(),
-            stderr: format!(
-                "Failed to execute SCONE command '{SCONECLI_BINARY} {}': Neither '{SCONECLI_BINARY}' nor 'docker' is installed (ERROR 20154-13302-17922)",
-                args.join(" ")
-            ),
+fn get_attest_arg_registry() -> Vec<VersionedArg> {
+    vec![
+        VersionedArg {
+            flag: "--accept-unverifiable-pcs-certs",
+            supported: ">=7.0.0".parse().unwrap(),
         },
-    }
+        VersionedArg {
+            flag: "--accept-revoked-pcs-certs",
+            supported: ">=7.0.0".parse().unwrap(),
+        },
+    ]
 }
 
-pub const DEBUG_SCONE_CLI_ENV: &[(&str, &str)] = &[
-    ("SCONE_PRODUCTION", "0"),
-    ("SCONE_NO_TIME_THREAD", "1"),
-    ("SCONE_MODE", "sim"),
-];
-
-/// Executes a SCONE cli command in one of the supported modes.
-///
-/// # Examples
-/// ```ignore
-/// exec_scone!(debug, "cas", "list");
-/// exec_scone!(production, "cas", "list");
-/// exec_scone!(custom, env, "cas", "list");                       // env_remove defaults to []
-/// exec_scone!(custom, env, remove ["SCONE_CONFIG_ID"], "cas", "list");
-/// ```
-#[macro_export]
-macro_rules! exec_scone {
-    (debug, $( $arg:expr ),+ $(,)?) => {{
-        $crate::execute_scone_cli(
-            &[$( $arg.to_string() ),+],
-            $crate::DEBUG_SCONE_CLI_ENV.iter().copied(),
-            Vec::<&str>::new(),
-        )
-    }};
-
-    (production, $( $arg:expr ),+ $(,)?) => {{
-        $crate::execute_scone_cli(
-            &[$( $arg.to_string() ),+],
-            Vec::<(&str, &str)>::new(),
-            Vec::<&str>::new(),
-        )
-    }};
-
-    (custom, $env:expr, remove $env_remove:expr, $( $arg:expr ),+ $(,)?) => {{
-        $crate::execute_scone_cli(
-            &[$( $arg.to_string() ),+],
-            $env,
-            $env_remove,
-        )
-    }};
-
-    (custom, $env:expr, $( $arg:expr ),+ $(,)?) => {{
-        $crate::execute_scone_cli(
-            &[$( $arg.to_string() ),+],
-            $env,
-            Vec::<&str>::new(),
-        )
-    }};
-}
-
-/// Executes a SCONE cli command in production mode. See `exec_scone!()` for other modes.
-#[macro_export]
-macro_rules! scone {
-    ( $( $arg:expr ),+ $(,)? ) => {{
-        $crate::execute_scone_cli(
-            $crate::SCONECLI_BINARY,
-            &[$( $arg.to_string() ),+],
-            Vec::<(&str, &str)>::new(),
-            Vec::<&str>::new(),
-        )
-    }};
-}
-
-fn construct_docker_env(envs: &[(String, String)]) -> Vec<String> {
-    let mut args = vec![];
-    for (k, v) in envs {
-        args.push("-e".to_string());
-        args.push(format!("{k}={v}"));
-    }
-    args
-}
-
-fn shell_quote(s: &str) -> String {
-    format!("'{}'", s.replace('\'', r"'\''"))
-}
-
-fn build_docker_command(binary: &str, args: &[String], env_args: &[String]) -> String {
-    let repo =
-        env::var("SCONECTL_REPO").unwrap_or_else(|_| "registry.scontain.com/sconectl".to_string());
-
-    let vol = match env::var("DOCKER_HOST") {
-        Ok(val) => {
-            if val.starts_with("unix://") {
-                let vol = val.strip_prefix("unix://").unwrap_or(&val).to_string();
-                format!(r#"-e DOCKER_HOST="{val}" -v "{vol}":"{vol}""#)
-            } else if val.starts_with("tcp://") {
-                warn!(
-                    "Docker socket with TCP schema was detected. Will use DOCKER_HOST={val} to access docker socket inside container."
-                );
-                format!(r#"-e DOCKER_HOST="{val}""#)
-            } else if val.parse::<Ipv4Addr>().is_ok() || val.parse::<SocketAddrV4>().is_ok() {
-                warn!(
-                    "IP address was detected. Will use DOCKER_HOST=tcp://{val} to access docker socket inside container."
-                );
-                format!(r#"-e DOCKER_HOST="tcp://{val}""#)
-            } else {
-                warn!("Docker socket: {} with unknown schema was detected.", val);
-                r#"-e DOCKER_HOST=/var/run/docker.sock -v /var/run/docker.sock:/var/run/docker.sock"#.to_string()
-            }
-        }
-        Err(_e) => "-v /var/run/docker.sock:/var/run/docker.sock".to_string(),
-    };
-
-    let env_vars_str = env_args.join(" ");
-    let quoted_args: Vec<String> = args.iter().map(|a| shell_quote(a)).collect();
-    let scone_command = format!("{binary} {}", quoted_args.join(" "));
-
-    let docker_command = format!(
-        r#"docker run --rm --platform linux/amd64 --add-host=host.docker.internal:host-gateway {DOCKER_NETWORK} {env_vars_str} --entrypoint="" -e "SCONECTL_REPO={repo}" {vol} -v "$HOME/.docker:/home/root/.docker" -v "$HOME/.cas:/home/nonroot/.cas" -v "$HOME/.scone:/home/nonroot/.scone" -v "$PWD:/wd" -w /wd --user $(id -u):$(id -g) --group-add $(getent group docker | cut -d: -f3)   {repo}/sconecli:{} sh -c '{scone_command}'"#,
-        get_version()
+fn filter_args_for_scone_cli(args: Vec<String>, scone_cli_version: &Version) -> Vec<String> {
+    let registry = get_attest_arg_registry();
+    let base_version = Version::new(
+        scone_cli_version.major,
+        scone_cli_version.minor,
+        scone_cli_version.patch,
     );
-    info!("Executing: {docker_command}");
-    docker_command
+    let mut out = Vec::with_capacity(args.len());
+    for arg in args {
+        if let Some(entry) = registry.iter().find(|e| e.flag == arg.as_str()) {
+            if entry.supported.matches(&base_version) {
+                out.push(arg);
+            } else {
+                warn!(
+                    "Dropping attest arg '{arg}' — not supported by Scone CLI {scone_cli_version}"
+                );
+            }
+        } else {
+            out.push(arg);
+        }
+    }
+    out
+}
+
+fn contains_version_gated_arg(other_args: &[String]) -> bool {
+    other_args.iter().any(|a| {
+        get_attest_arg_registry()
+            .iter()
+            .any(|e| e.flag == a.as_str())
+    })
+}
+
+pub struct SconeCli;
+
+impl SconeCli {
+    pub fn version() -> anyhow::Result<Version> {
+        let args = vec!["--version".to_string()];
+        let output =
+            Self::try_execute_scone_cli(&args, Vec::<(&str, &str)>::new(), "31045-9872-4516")?;
+        let word = output
+            .split_whitespace()
+            .last()
+            .with_context(|| format!("Unexpected empty output from scone --version: '{output}'"))?;
+        Version::parse(word).with_context(|| {
+            format!("Could not parse Scone CLI version: '{word}' is not a valid semver")
+        })
+    }
+
+    fn try_execute_scone_cli<S: AsRef<str>>(
+        args: &[String],
+        env: impl IntoIterator<Item = (S, S)>,
+        error_code: &str,
+    ) -> anyhow::Result<String> {
+        let SconeCliCommandResult {
+            exit_code,
+            stdout,
+            stderr,
+        } = execute_scone_cli(args, env, vec!["SCONE_CONFIG_ID"]);
+        if exit_code != 0 {
+            bail!("Scone CLI command failed (ERROR {error_code}): {stderr}");
+        }
+        Ok(stdout)
+    }
+
+    pub fn retrieve_signer() -> anyhow::Result<String> {
+        debug!("Determining the signer identity");
+        let args = vec!["self".to_string(), "show-session-signing-key".to_string()];
+        let stdout =
+            Self::try_execute_scone_cli(&args, Vec::<(&str, &str)>::new(), "9808-322-4776")?;
+        Ok(stdout.trim().to_string())
+    }
+
+    pub fn cas_attest(
+        scone_cas_addr: &str,
+        ignore_signer: bool,
+        other_args: Vec<String>,
+    ) -> anyhow::Result<String> {
+        let other_args = if contains_version_gated_arg(&other_args) {
+            let scone_cli_version = Self::version()?;
+            filter_args_for_scone_cli(other_args, &scone_cli_version)
+        } else {
+            other_args
+        };
+
+        if ignore_signer {
+            debug!("Attesting CAS {scone_cas_addr} without signer");
+            let mut args = vec![
+                "cas".to_string(),
+                "attest".to_string(),
+                scone_cas_addr.to_string(),
+                "--only_for_testing-ignore-signer".to_string(),
+            ];
+            args.extend(other_args);
+            return Self::try_execute_scone_cli(
+                &args,
+                Vec::<(&str, &str)>::new(),
+                "1573-25311-11120",
+            );
+        }
+
+        debug!("Attesting CAS {scone_cas_addr} with signer {K_MRSIGNER_DB}");
+        let mut args = vec![
+            "cas".to_string(),
+            "attest".to_string(),
+            scone_cas_addr.to_string(),
+            "--mrsigner".to_string(),
+            K_MRSIGNER_DB.to_string(),
+        ];
+        args.extend(other_args);
+        Self::try_execute_scone_cli(&args, Vec::<(&str, &str)>::new(), "7520-30768-31405")
+    }
+
+    pub fn sign_cas_policy(
+        cas_policy_file_name: &str,
+        dest: OutputDest,
+    ) -> anyhow::Result<PersistedFile> {
+        debug!("Signing CAS policy {cas_policy_file_name}");
+        let args = vec![
+            "session".to_string(),
+            "sign".to_string(),
+            cas_policy_file_name.to_string(),
+        ];
+        let stdout =
+            Self::try_execute_scone_cli(&args, Vec::<(&str, &str)>::new(), "28666-19528-6399")?;
+
+        write_to_dest(&dest, stdout.as_bytes())
+    }
+
+    pub fn encrypt_cas_policy(
+        cas_policy_file_name: &str,
+        cas_addr: &str,
+        dest: OutputDest,
+    ) -> anyhow::Result<PersistedFile> {
+        debug!("Encrypting CAS policy {cas_policy_file_name}");
+        let args = vec![
+            "session".to_string(),
+            "encrypt".to_string(),
+            cas_policy_file_name.to_string(),
+            "--cas".to_string(),
+            cas_addr.to_string(),
+        ];
+        let stdout =
+            Self::try_execute_scone_cli(&args, Vec::<(&str, &str)>::new(), "9918-20782-3163")?;
+
+        write_to_dest(&dest, stdout.as_bytes())
+    }
+
+    pub fn read_cas_policy_from_name(
+        policy_name: &str,
+        scone_cas_addr: &str,
+    ) -> anyhow::Result<String> {
+        info!("Reading session ({policy_name}) from cas at {scone_cas_addr}");
+        let args = vec![
+            "session".to_string(),
+            "read".to_string(),
+            "--cas".to_string(),
+            scone_cas_addr.to_string(),
+            policy_name.to_string(),
+        ];
+        let stdout =
+            Self::try_execute_scone_cli(&args, Vec::<(&str, &str)>::new(), "129012-1221-72811")?;
+        Ok(stdout)
+    }
+
+    pub fn calculate_session_hash(policy_content: impl AsRef<[u8]>) -> anyhow::Result<String> {
+        debug!("Calculating session hash from policy content");
+
+        let mut tmp_policy_file = NamedTempFile::new()?;
+        tmp_policy_file.write_all(policy_content.as_ref())?;
+
+        tmp_policy_file.flush()?;
+
+        let filename = tmp_policy_file.path().to_string_lossy();
+        let args = vec![
+            "session".to_string(),
+            "calculate-hash".to_string(),
+            filename.into_owned(),
+        ];
+
+        let stdout =
+            Self::try_execute_scone_cli(&args, Vec::<(&str, &str)>::new(), "3997-10374-20206")?;
+
+        Ok(stdout.trim().to_owned())
+    }
+    pub fn scone_cas_show_identification(
+        arg: Option<&str>,
+        cas_address: &str,
+    ) -> anyhow::Result<String> {
+        let mut args = vec!["cas".to_string(), "show-identification".to_string()];
+        if let Some(a) = arg {
+            args.push(a.to_string());
+        }
+        args.push(cas_address.to_string());
+        let stdout =
+            Self::try_execute_scone_cli(&args, Vec::<(&str, &str)>::new(), "6621-27685-4998")?;
+        Ok(stdout.trim().to_string())
+    }
+
+    pub fn cas_attest_with_offline_report(
+        scone_cas_addr: &str,
+        dcap_report_json: &str,
+        nonce: &str,
+        ignore_signer: bool,
+        other_args: Vec<String>,
+    ) -> anyhow::Result<String> {
+        let mut more_args = vec![
+            "--nonce".to_string(),
+            nonce.to_string(),
+            "--offline-report".to_string(),
+            dcap_report_json.to_string(),
+        ];
+        more_args.extend(other_args);
+        Self::cas_attest(scone_cas_addr, ignore_signer, more_args)
+    }
+
+    pub fn execute_scone_session_command(args: &[String]) -> Result<String, SconeCliCommandResult> {
+        let mut full_args = vec!["session".to_string()];
+        full_args.extend_from_slice(args);
+        run_scone_command(&full_args, "16096-6804-19408")
+    }
+
+    pub fn execute_scone_command(args: &[String]) -> Result<String, SconeCliCommandResult> {
+        run_scone_command(args, "27785-7589-20705")
+    }
+
+    pub fn execute_scone_cas_command(args: &[String]) -> Result<String, SconeCliCommandResult> {
+        let mut full_args = vec!["cas".to_string()];
+        full_args.extend_from_slice(args);
+        run_scone_command(&full_args, "30503-16074-21257")
+    }
+}
+
+fn run_scone_command(args: &[String], error_code: &str) -> Result<String, SconeCliCommandResult> {
+    let SconeCliCommandResult {
+        exit_code,
+        stdout,
+        mut stderr,
+    } = execute_scone_cli(args, Vec::<(&str, &str)>::new(), ["SCONE_CONFIG_ID"]);
+    if exit_code != 0 {
+        stderr = format!(
+            "Scone CLI command '{SCONECLI_BINARY} {}' failed (ERROR {error_code}): \n{stderr}",
+            args.join(" ")
+        );
+        Err(SconeCliCommandResult {
+            exit_code,
+            stdout,
+            stderr,
+        })
+    } else {
+        Ok(stdout)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn drops_unsupported_registry_flags() {
+        let v = Version::parse("6.0.6").unwrap();
+        let out = filter_args_for_scone_cli(
+            vec!["--accept-revoked-pcs-certs".into(), "--verbose".into()],
+            &v,
+        );
+        assert_eq!(out, vec!["--verbose".to_string()]);
+    }
+
+    #[test]
+    fn keeps_supported_flags_on_prerelease() {
+        let v = Version::parse("7.0.0-alpha.4").unwrap();
+        let out = filter_args_for_scone_cli(vec!["--accept-revoked-pcs-certs".into()], &v);
+        assert_eq!(out, vec!["--accept-revoked-pcs-certs".to_string()]);
+    }
+
+    #[test]
+    fn passes_through_non_registry_args() {
+        let v = Version::parse("6.0.6").unwrap();
+        let out = filter_args_for_scone_cli(vec!["--isvsvn".into(), "5".into()], &v);
+        assert_eq!(out, vec!["--isvsvn".to_string(), "5".to_string()]);
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -229,7 +229,26 @@ impl SconeCli {
         Ok(stdout)
     }
 
-    pub fn calculate_session_hash(policy_content: impl AsRef<[u8]>) -> anyhow::Result<String> {
+    pub fn calculate_session_hash_from_file<P: AsRef<Path>>(
+        policy_file_path: P,
+    ) -> anyhow::Result<String> {
+        let path_ref = policy_file_path.as_ref();
+        debug!("Calculating session hash of {:?}", path_ref);
+
+        let args = vec![
+            "session".to_string(),
+            "calculate-hash".to_string(),
+            path_ref.to_string_lossy().into_owned(),
+        ];
+
+        let stdout =
+            Self::try_execute_scone_cli(&args, Vec::<(&str, &str)>::new(), "19175-9146-3013")?;
+        Ok(stdout.trim().to_owned())
+    }
+
+    pub fn calculate_session_hash_from_content(
+        policy_content: impl AsRef<[u8]>,
+    ) -> anyhow::Result<String> {
         debug!("Calculating session hash from policy content");
 
         let mut tmp_policy_file = NamedTempFile::new()?;
@@ -238,16 +257,7 @@ impl SconeCli {
         tmp_policy_file.flush()?;
 
         let filename = tmp_policy_file.path().to_string_lossy();
-        let args = vec![
-            "session".to_string(),
-            "calculate-hash".to_string(),
-            filename.into_owned(),
-        ];
-
-        let stdout =
-            Self::try_execute_scone_cli(&args, Vec::<(&str, &str)>::new(), "3997-10374-20206")?;
-
-        Ok(stdout.trim().to_owned())
+        Self::calculate_session_hash_from_file(filename.as_ref())
     }
     pub fn scone_cas_show_identification(
         arg: Option<&str>,


### PR DESCRIPTION
This PR:

a. Moves more scone CLI functionalities from `kubectl_scone`

b. Changes the dectection of scone in spawn server/local installation as follows:
   1. ensures that (a/s)rpc_(exec/sh) fails when spawn server is not reachable 
          allows explicit fall-back on local execution through (a/s)rpc_or_local_(exec/sh) when this is not desired
   2. removes false negatives regarding whether scone is installed by adding SCONE_PRODUCTION=0 when executing scone --version.