### PR TITLE
fix: remove scone_config_id in checking scone install

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1633,7 +1633,7 @@ dependencies = [
 
 [[package]]
 name = "scone_cli"
-version = "3.1.0"
+version = "3.1.1"
 dependencies = [
  "anyhow",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scone_cli"
-version = "3.1.0"
+version = "3.1.1"
 edition = "2024"
 publish = false
 license = "Unlicense"

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -34,7 +34,7 @@ fn compute_scone_cli_command_type() -> SconeCliCommandType {
         SCONECLI_BINARY,
         ["--version"],
         [("SCONE_PRODUCTION", "0")],
-        ["SCONE_PRODUCTION"]
+        ["SCONE_PRODUCTION", "SCONE_CONFIG_ID"]
     );
 
     if exit_code == 0 {
@@ -68,6 +68,7 @@ pub fn local_scone_installed() -> bool {
     match Command::new(SCONECLI_BINARY)
         .arg("--version")
         .env_remove("SCONE_PRODUCTION")
+        .env_remove("SCONE_CONFIG_ID")
         .env("SCONE_PRODUCTION", "0")
         .output()
     {


### PR DESCRIPTION
From observation, it's possible that the `scone --version` command doesn't execute as intended if the environment has a `SCONE_CONFIG_ID`, this PR removes that, and ensure we can check if scone is installed
